### PR TITLE
Fix Ember 2.6.0 deprecation

### DIFF
--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
     return Ember.String.htmlSafe('display:none;')
   }),
 
-  setup: Ember.on('didInitAttrs', function () {
+  setup: Ember.on('init', function () {
     const parentView = this.get('parentView')
     parentView.on('click', (event) => {
       if (!Ember.ViewUtils.isSimpleClick(event)) {

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
-import Resolver from 'ember/resolver'
-import loadInitializers from 'ember/load-initializers'
+import Resolver from 'ember-resolver'
+import loadInitializers from 'ember-load-initializers'
 import config from './config/environment'
 
 let App

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver'
+import Resolver from 'ember-resolver'
 import config from '../../config/environment'
 
 const resolver = Resolver.create()


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* **Fixed** deprecation warning from Ember 2.6.0 to stop using `didInitAttrs` hook and instead use `init`.