### PR TITLE
Auto position

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ember install ember-frost-popover
 | ----------| ---------- | ----- | ----------- |
 | Action | `close` | | Close the popover and optionally fire an external action |
 | Option | `offset` | | The amount in pixels the popover should appear from the target (defaults to `10`) |
-| Option | `position` | `top`,`right`,`bottom`,`left`| The location of the popover relative to the target (defaults to `bottom`) |
+| Option | `position` | `top`,`right`,`bottom`,`left`, `auto`| The location of the popover relative to the target. When `auto` is specified, it will dynamically reorient the popover. For example, if position is `auto left`, the popover will display to the left when possible, otherwise it will display right. (defaults to `bottom`) |
 | Option | `closest` | boolean  | When true uses JQuery's [closest function](https://api.jquery.com/closest/). Otherwise just uses main selector `$(<target>)` (defaults to `false`).  |
 | Option | `excludePadding` | boolean  | When true removes the padding from position calculations (defaults to `false`).|
 | Option | `event |  | The event that will trigger the popover (defaults to on `click`). Uses [on()](http://api.jquery.com/on/)|

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -1,6 +1,31 @@
 import Ember from 'ember'
 import layout from '../templates/components/frost-popover'
 import $ from 'jquery'
+
+function checkLeft (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.left > 0 + popoverRect.width + offset) {
+    result = 'left'
+  }
+  return result
+}
+function checkRight (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.left < 0 + popoverRect.width + offset) {
+    result = 'right'
+  }
+  return result
+}
+function checkTop (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.top > 0 + popoverRect.height + offset) {
+    result = 'top'
+  }
+  return result
+}
+function checkBottom (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.top < 0 + popoverRect.height + offset) {
+    result = 'bottom'
+  }
+  return result
+}
 export default Ember.Component.extend({
   layout,
   visible: false,
@@ -8,9 +33,10 @@ export default Ember.Component.extend({
   closest: false,
   offset: 10,
   position: 'bottom',
+  autoPosition: null,
   index: 0,
   excludePadding: false,
-  classNameBindings: ['position', 'visible:visible:invisible'],
+  classNameBindings: ['visible:visible:invisible', 'autoPosition'],
   classNames: ['tooltip-frost-popover'],
   didRender () {
     Ember.run.next(() => {
@@ -50,47 +76,77 @@ export default Ember.Component.extend({
       let top
       let left
       let excludePadding = this.get('excludePadding')
-      switch (position) {
-        case 'bottom':
-          top = targetRect.bottom + this.get('offset')
-          left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            top -= parseInt(cs.getPropertyValue('padding-bottom'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
-        case 'top':
-          top = targetRect.top - popoverRect.height - this.get('offset')
-          left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            top += parseInt(cs.getPropertyValue('padding-top'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
-        case 'left':
-          top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
-          left = targetRect.left - popoverRect.width - this.get('offset')
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            left += parseInt(cs.getPropertyValue('padding-left'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
-        case 'right':
-          top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
-          left = targetRect.right + this.get('offset')
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            left -= parseInt(cs.getPropertyValue('padding-right'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
+      let offset = this.get('offset')
+      var positions = position.split(' ')
+      console.log(positions)
+      if (positions[0] === 'auto') {
+        var elementPosition = targetElement.getBoundingClientRect()
+        let tempAutoPosition = null
+        if (positions[1] === 'left') {
+          tempAutoPosition = checkBottom(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkTop(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkRight(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkLeft(elementPosition, popoverRect, offset, tempAutoPosition)
+        } else if (positions[1] === 'right') {
+          tempAutoPosition = checkBottom(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkTop(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkLeft(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkRight(elementPosition, popoverRect, offset, tempAutoPosition)
+        } else if (positions[1] === 'bottom') {
+          tempAutoPosition = checkLeft(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkRight(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkTop(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkBottom(elementPosition, popoverRect, offset, tempAutoPosition)
+        } else {
+          tempAutoPosition = checkLeft(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkRight(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkBottom(elementPosition, popoverRect, offset, tempAutoPosition)
+          tempAutoPosition = checkTop(elementPosition, popoverRect, offset, tempAutoPosition)
+        }
+        console.log(tempAutoPosition)
+        this.set('autoPosition', tempAutoPosition)
+      }
+      let autoPosition = this.get('autoPosition')
+      if (positions[0] === 'bottom' || autoPosition === 'bottom') {
+        this.set('autoPosition', 'bottom')
+        top = targetRect.bottom + this.get('offset')
+        left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
+        if (excludePadding) {
+          let cs = window.getComputedStyle(targetElement)
+          top -= parseInt(cs.getPropertyValue('padding-bottom'))
+        }
+        popoverElement.style.top = top + 'px'
+        popoverElement.style.left = left + 'px'
+      } else if (positions[0] === 'top' || autoPosition === 'top') {
+        this.set('autoPosition', 'top')
+        top = targetRect.top - popoverRect.height - this.get('offset')
+        left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
+        if (excludePadding) {
+          let cs = window.getComputedStyle(targetElement)
+          top += parseInt(cs.getPropertyValue('padding-top'))
+        }
+        popoverElement.style.top = top + 'px'
+        popoverElement.style.left = left + 'px'
+      } else if (positions[0] === 'left' || autoPosition === 'left') {
+        this.set('autoPosition', 'left')
+        top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
+        left = targetRect.left - popoverRect.width - this.get('offset')
+        if (excludePadding) {
+          let cs = window.getComputedStyle(targetElement)
+          left += parseInt(cs.getPropertyValue('padding-left'))
+        }
+        popoverElement.style.top = top + 'px'
+        popoverElement.style.left = left + 'px'
+      } else if (positions[0] === 'right' || autoPosition === 'right') {
+        this.set('autoPosition', 'right')
+        top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
+        left = targetRect.right + this.get('offset')
+        if (excludePadding) {
+          let cs = window.getComputedStyle(targetElement)
+          left -= parseInt(cs.getPropertyValue('padding-right'))
+        }
+        popoverElement.style.top = top + 'px'
+        popoverElement.style.left = left + 'px'
       }
     }
   }

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -61,8 +61,9 @@ export default Ember.Component.extend({
       this.toggleProperty('visible')
       let position = this.get('position')
       let targetRect
-      // eslint-disable-next-line max-len
-      let targetElement = this.get('closest') ? this.$().closest(this.get('target'))[this.get('index')] : this.get('parentView').$(this.get('target'))[this.get('index')]
+      let targetElement = this.get('closest')
+      ? this.$().closest(this.get('target'))[this.get('index')] : this.get('parentView')
+      .$(this.get('target'))[this.get('index')]
       targetRect = {
         top: targetElement.offsetTop,
         left: targetElement.offsetLeft,
@@ -115,8 +116,6 @@ export default Ember.Component.extend({
           let cs = window.getComputedStyle(targetElement)
           top -= parseInt(cs.getPropertyValue('padding-bottom'))
         }
-        popoverElement.style.top = top + 'px'
-        popoverElement.style.left = left + 'px'
       } else if (positions[0] === 'top' || autoPosition === 'top') {
         this.set('autoPosition', 'top')
         top = targetRect.top - popoverRect.height - this.get('offset')
@@ -125,8 +124,6 @@ export default Ember.Component.extend({
           let cs = window.getComputedStyle(targetElement)
           top += parseInt(cs.getPropertyValue('padding-top'))
         }
-        popoverElement.style.top = top + 'px'
-        popoverElement.style.left = left + 'px'
       } else if (positions[0] === 'left' || autoPosition === 'left') {
         this.set('autoPosition', 'left')
         top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
@@ -135,9 +132,7 @@ export default Ember.Component.extend({
           let cs = window.getComputedStyle(targetElement)
           left += parseInt(cs.getPropertyValue('padding-left'))
         }
-        popoverElement.style.top = top + 'px'
-        popoverElement.style.left = left + 'px'
-      } else if (positions[0] === 'right' || autoPosition === 'right') {
+      } else {
         this.set('autoPosition', 'right')
         top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
         left = targetRect.right + this.get('offset')
@@ -145,9 +140,9 @@ export default Ember.Component.extend({
           let cs = window.getComputedStyle(targetElement)
           left -= parseInt(cs.getPropertyValue('padding-right'))
         }
-        popoverElement.style.top = top + 'px'
-        popoverElement.style.left = left + 'px'
       }
+      popoverElement.style.top = top + 'px'
+      popoverElement.style.left = left + 'px'
     }
   }
 })

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -4,14 +4,14 @@ frost-popover testbed
 {{#frost-popover target='.target'}}
   <span class='inside'>Inside</span>
 {{/frost-popover}}
-
+<br><br><br><br><br><br><br><br>
 <div class='close'>
 closest testbed
-{{#frost-popover target='.close' excludePadding=true closest=true}}
+{{#frost-popover target='.close' excludePadding=true closest=true position='auto left'}}
   <span class='inside'>Closest</span>
 {{/frost-popover}}
 </div>
-
+<br><br><br><br><br><br><br>
 <div class='close'>
 closest testbed
 {{#frost-popover target='.close' excludePadding=true closest=true position='top'}}


### PR DESCRIPTION
#minor#
Requires: https://github.com/ciena-frost/ember-frost-popover/pull/6
Adds feature to https://github.com/ciena-frost/ember-frost-popover/pull/6
# Changelog
- When "auto" is specified, it will dynamically reorient the popover. For example, if placement is "auto left", the popover will display to the left when possible, otherwise it will display right.