### PR TITLE
Adds viewport containment and other features

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ ember install ember-frost-popover
 | Option | `event` |  | The event that will trigger the popover (defaults to on `click`). Uses [on()](http://api.jquery.com/on/)|
 | Option | `target` |  | The selector string of the target that activates the popover |
 | Option | `viewport`| | The selector for the viewport. Defaults to 'body' |
+| Option | `resize` | | If set to false, will prevent the browser from resizing at the edges of the viewport. This preserves the *expand to fit content* behavior of `width: auto`. It defaults to true. |
 
 ## Specifying Target
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,20 @@ ember install ember-frost-popover
 | ----------| ---------- | ----- | ----------- |
 | Action | `close` | | Close the popover and optionally fire an external action |
 | Option | `offset` | | The amount in pixels the popover should appear from the target (defaults to `10`) |
-| Option | `position` | `top`,`right`,`bottom`,`left`| The location of the popover relative to the target (defaults to `bottom`) |
+| Option | `position` | `top`,`right`,`bottom`,`left`, `auto`| The location of the popover relative to the target. When `auto` is specified, it will dynamically reorient the popover. For example, if position is `auto left`, the popover will display to the left when possible, otherwise it will display right. (defaults to `bottom`) |
 | Option | `closest` | boolean  | When true uses JQuery's [closest function](https://api.jquery.com/closest/). Otherwise just uses main selector `$(<target>)` (defaults to `false`).  |
 | Option | `excludePadding` | boolean  | When true removes the padding from position calculations (defaults to `false`).|
-| Option | `event |  | The event that will trigger the popover (defaults to on `click`). Uses [on()](http://api.jquery.com/on/)|
-| | |  ||
+| Option | `event` |  | The event that will trigger the popover (defaults to on `click`). Uses [on()](http://api.jquery.com/on/)|
+| Option | `target` |  | The selector string of the target that activates the popover |
+| Option | `viewport`| | The selector for the viewport. Defaults to 'body' |
 
+## Specifying Target
 
-## Examples
+If the `frost-popover` component is placed next to the `target`, be careful to use a selector that will uniquely identify the `target`. If it is nested inside the `target`, you can set `closest` to true which will search the nearest ancestor from the `popover`.
+
+### A Note On Positioning
+
+The `popover` is displayed using `absolute` positioning. The `target`'s coordinates are determined from the `offsets` from its parent's container. In most cases, the `target` will occupy the same stacking context as the `popover`. However, if the `target` has `absolute` positioning and the `popover` is nested, they won't share the same stacking context and the `popover`'s position will be erroneous. If the `target` must be `absolute`, then it's best to place the `popover` next to it.
 
 **template.hbs**
 

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -1,96 +1,286 @@
 import Ember from 'ember'
 import layout from '../templates/components/frost-popover'
 import $ from 'jquery'
-export default Ember.Component.extend({
+import PropTypeMixin, {PropTypes} from 'ember-prop-types'
+
+const arrowMargin = 5
+const maxPlacementRetries = 5
+
+export default Ember.Component.extend(PropTypeMixin, {
   layout,
-  visible: false,
-  event: 'click',
-  closest: false,
-  offset: 10,
-  position: 'bottom',
-  index: 0,
-  excludePadding: false,
   classNameBindings: ['position', 'visible:visible:invisible'],
   classNames: ['tooltip-frost-popover'],
-  didRender () {
+  propTypes: {
+    closest: PropTypes.bool,
+    event: PropTypes.string,
+    excludePadding: PropTypes.bool,
+    index: PropTypes.number,
+    offset: PropTypes.number,
+    position: PropTypes.string,
+    resize: PropTypes.bool,
+    viewport: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
+      PropTypes.func
+    ])
+  },
+
+  getDefaultProps () {
+    return {
+      closest: false,
+      event: 'click',
+      excludePadding: false,
+      index: 0,
+      offset: 10,
+      position: 'bottom',
+      resize: true,
+      viewport: 'body',
+      visible: false
+    }
+  },
+
+  didInsertElement () {
     Ember.run.next(() => {
-      const context = this
-      if (this.get('closest')) {
-        this.$().closest(this.get('target')).on(this.get('event'), function () {
-          context.send('togglePopover')
-        })
-      } else {
-        $(this.get('target')).on(this.get('event'), function () {
-          context.send('togglePopover')
-        })
+      const target = this.getTarget()
+      const event = this.get('event')
+
+      this._eventHandler = (event) => {
+        const popover = this.get('element')
+        if ($(event.target).closest(popover).length === 0) {
+          this.send('togglePopover')
+        }
       }
+
+      $(target).on(event, this._eventHandler)
     })
   },
+
+  willDestroyElement () {
+    const target = this.getTarget()
+    const event = this.get('event')
+    $(target).off(event, this._eventHandler)
+    this.unregisterClickOff()
+  },
+
+  registerClickOff () {
+    Ember.run.next(this, () => {
+      const elementId = this.get('elementId')
+      $('html').on(`click.container.${elementId}`, (event) => {
+        let popover = this.get('element')
+        if ($(event.target).closest(popover).length === 0) {
+          this.set('visible', false)
+          this.unregisterClickOff()
+        }
+      })
+    })
+  },
+
+  unregisterClickOff () {
+    const elementId = this.get('elementId')
+    $('html').off(`click.container.${elementId}`)
+  },
+
+  /**
+   * Gets the computed style for element
+   * @param {DOMElement} element - the element to target
+   * @param {String} properties - the css properties to get (must be a number property)
+   * @returns {Number[]} the parsed property values
+   */
+  getComputedStyle (element, properties) {
+    let cs = window.getComputedStyle(element)
+    let values = {}
+    properties.forEach((property) => {
+      values[property] = parseInt(cs.getPropertyValue(property))
+    })
+
+    return values
+  },
+
+  getTarget () {
+    const target = this.get('target')
+    const index = this.get('index')
+    const parent = this.get('parentView')
+    return this.get('closest') ? this.$().closest(target)[index]
+      : (parent.$() ? parent.$(target)[index] : $(target)[index])
+  },
+
+  getViewport () {
+    const viewportProp = this.get('viewport')
+
+    switch (typeof viewportProp) {
+      case 'object':
+        return viewportProp
+      case 'string':
+        return $(viewportProp)[0]
+      case 'function':
+        return viewportProp.call(this, this.getTarget())
+    }
+  },
+
+  /**
+   * Calculates the offsets needed to keep the the popover within the viewport. If the attachment
+   * is horizontal (left/right) then the popover can only be constrained vertical. If if is vertical
+   * then the popover is constrained horizontally.
+   * @param {String} attachment - (top/left/right/bottom)
+   * @returns {Object} the delta (top, left)
+   */
+  getViewportAdjustments (attachment) {
+    const popoverRect = this.get('element').getBoundingClientRect()
+    const viewportRect = $(this.get('viewport'))[0].getBoundingClientRect()
+
+    let delta = {
+      top: 0,
+      left: 0
+    }
+
+    if (attachment === 'left' || attachment === 'right') {
+      if (popoverRect.top < viewportRect.top) {
+        delta.top = viewportRect.top - popoverRect.top
+      } else if (popoverRect.top + popoverRect.height > viewportRect.bottom) {
+        delta.top = viewportRect.bottom - popoverRect.height - popoverRect.top
+      }
+    } else {
+      if (popoverRect.left < viewportRect.left) {
+        delta.left = viewportRect.left - popoverRect.left
+      } else if (popoverRect.left + popoverRect.width > viewportRect.right) {
+        delta.left = viewportRect.right - popoverRect.width - popoverRect.left
+      }
+    }
+
+    return delta
+  },
+
+  /**
+   * Gets the box calculations using relative offsets
+   * @param {DOMElement} element - the target element
+   * @returns {Rect} the rect structure using the element's offsets rather than client rect
+   */
+  getOffsetRect (element) {
+    const excludePadding = this.get('excludePadding')
+    const paddingCss = this.getComputedStyle(element, [
+      'padding-top',
+      'padding-left',
+      'padding-right',
+      'padding-bottom'
+    ])
+
+    const rect = {
+      top: element.offsetTop,
+      left: element.offsetLeft,
+      bottom: element.offsetTop + element.offsetHeight,
+      right: element.offsetLeft + element.offsetWidth,
+      width: element.offsetWidth,
+      height: element.offsetHeight
+    }
+
+    if (excludePadding) {
+      rect.top += paddingCss['padding-top']
+      rect.left += paddingCss['padding-left']
+      rect.bottom -= paddingCss['padding-bottom']
+      rect.right -= paddingCss['padding-right']
+    }
+
+    return rect
+  },
+
+  place () {
+    let position = this.get('position')
+    let targetElement = this.getTarget()
+    let popoverElement = this.get('element')
+    let $popoverElement = $(popoverElement)
+    let popoverRect = popoverElement.getBoundingClientRect()
+    let targetRect = this.getOffsetRect(targetElement)
+    let parentRect = this.getOffsetRect(targetElement.parentElement)
+
+    let top, left, bottom, right
+
+    switch (position) {
+      case 'bottom':
+        top = targetRect.bottom + this.get('offset')
+        left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
+        break
+      case 'top':
+        bottom = parentRect.height - (targetRect.top - this.get('offset'))
+        left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
+        break
+      case 'left':
+        top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
+        right = parentRect.width - (targetRect.left - this.get('offset'))
+        break
+      case 'right':
+        top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
+        left = targetRect.right + this.get('offset')
+        break
+    }
+
+    // need to apply the changes before viewport adjustments can be made
+    $popoverElement.css({
+      top,
+      right,
+      bottom,
+      left,
+      // forced to prevent browser from resizing at the edges of the viewport
+      width: this.get('resize') ? 'auto' : popoverRect.width,
+      height: this.get('resize') ? 'auto' : popoverRect.height
+    })
+
+    return {
+      top,
+      right,
+      bottom,
+      left
+    }
+  },
+
+  /**
+   * Attempts to place the popover repeating up to maxPlacementRetries since every placement could
+   * potential cause reflows/relayouts making our center calculations inaccurate.
+   * @returns {Object} the final placement offset
+   */
+  resolvePlacement () {
+    let offset = this.place()
+    let prevOffset = offset
+    let maxTries = maxPlacementRetries
+    do {
+      prevOffset = offset
+      offset = this.place()
+      --maxTries
+    }
+    while ((offset.top !== prevOffset.top || offset.left !== prevOffset.left) && maxTries > 0)
+
+    return offset
+  },
+
   actions: {
     close () {
-      if (this.get('isDestroyed')) { return }
+      if (this.get('isDestroyed')) {
+        return
+      }
       this.set('visible', false)
+      this.unregisterClickOff()
     },
     togglePopover () {
       this.toggleProperty('visible')
-      let position = this.get('position')
-      let targetRect
-      // eslint-disable-next-line max-len
-      let targetElement = this.get('closest') ? this.$().closest(this.get('target'))[this.get('index')] : this.get('parentView').$(this.get('target'))[this.get('index')]
-      targetRect = {
-        top: targetElement.offsetTop,
-        left: targetElement.offsetLeft,
-        bottom: targetElement.offsetTop + targetElement.offsetHeight,
-        right: targetElement.offsetLeft + targetElement.offsetWidth,
-        width: targetElement.offsetWidth,
-        height: targetElement.offsetHeight
-      }
-      let popoverElement = this.get('element')
-      let popoverRect = popoverElement.getBoundingClientRect()
-      let top
-      let left
-      let excludePadding = this.get('excludePadding')
-      switch (position) {
-        case 'bottom':
-          top = targetRect.bottom + this.get('offset')
-          left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            top -= parseInt(cs.getPropertyValue('padding-bottom'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
-        case 'top':
-          top = targetRect.top - popoverRect.height - this.get('offset')
-          left = targetRect.left + targetRect.width / 2 - popoverRect.width / 2
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            top += parseInt(cs.getPropertyValue('padding-top'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
-        case 'left':
-          top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
-          left = targetRect.left - popoverRect.width - this.get('offset')
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            left += parseInt(cs.getPropertyValue('padding-left'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
-        case 'right':
-          top = targetRect.top + targetRect.height / 2 - popoverRect.height / 2
-          left = targetRect.right + this.get('offset')
-          if (excludePadding) {
-            let cs = window.getComputedStyle(targetElement)
-            left -= parseInt(cs.getPropertyValue('padding-right'))
-          }
-          popoverElement.style.top = top + 'px'
-          popoverElement.style.left = left + 'px'
-          break
+      const position = this.get('position')
+
+      if (this.get('visible')) {
+        this.registerClickOff()
+        let offset = this.resolvePlacement()
+
+        const delta = this.getViewportAdjustments(position)
+
+        // apply delta to contain the popover inside the viewport
+        $(this.get('element')).css({
+          top: offset.top + delta.top,
+          left: offset.left + delta.left
+        })
+        // apply the negative delta on the arrow
+        this.$('.tooltip-arrow').css({
+          marginLeft: -delta.left - arrowMargin,
+          marginTop: -delta.top - arrowMargin
+        })
+      } else {
+        this.unregisterClickOff()
       }
     }
   }

--- a/addon/components/util.js
+++ b/addon/components/util.js
@@ -1,0 +1,59 @@
+/**
+ * Checks if the popover can be positioned on the left
+ * @param {Rect} elementPosition - the element client rect
+ * @param {Rect} popoverRect - the popover client rect
+ * @param {Number} offset - the amount of offset requested
+ * @param {String} result - the current position
+ * @returns {String} the new result
+ */
+export function checkLeft (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.left > 0 + popoverRect.width + offset) {
+    result = 'left'
+  }
+  return result
+}
+
+/**
+ * Checks if the popover can be positioned on the right
+ * @param {Rect} elementPosition - the element client rect
+ * @param {Rect} popoverRect - the popover client rect
+ * @param {Number} offset - the amount of offset requested
+ * @param {String} result - the current position
+ * @returns {String} the new result
+ */
+export function checkRight (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.left < 0 + popoverRect.width + offset) {
+    result = 'right'
+  }
+  return result
+}
+
+/**
+ * Checks if the popover can be positioned on the top
+ * @param {Rect} elementPosition - the element client rect
+ * @param {Rect} popoverRect - the popover client rect
+ * @param {Number} offset - the amount of offset requested
+ * @param {String} result - the current position
+ * @returns {String} the new result
+ */
+export function checkTop (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.top > 0 + popoverRect.height + offset) {
+    result = 'top'
+  }
+  return result
+}
+
+/**
+ * Checks if the popover can be positioned on the bottom
+ * @param {Rect} elementPosition - the element client rect
+ * @param {Rect} popoverRect - the popover client rect
+ * @param {Number} offset - the amount of offset requested
+ * @param {String} result - the current position
+ * @returns {String} the new result
+ */
+export function checkBottom (elementPosition, popoverRect, offset, result) {
+  if (elementPosition.top < 0 + popoverRect.height + offset) {
+    result = 'bottom'
+  }
+  return result
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,19 +1,25 @@
+@import 'node_modules/ember-frost-core/addon/styles/addon';
+
+$tooltip-shadow: rgba(0, 0, 0, .2);
+
 .tooltip-frost-popover {
   max-width: inherit;
   pointer-events: auto;
+  border-radius: 3px;
+  border-color: $frost-color-lgrey-1;
   background-color: white;
-  color: rgb(0, 0, 0);
-  border: solid 1px black;
+  box-shadow: 0 0 5px $tooltip-shadow;
+  color: $frost-color-grey-1;
   text-decoration: none;
   position: absolute;
   display: block;
-  padding: 0 20px;
+  padding: .5em;
   opacity: 1;
   transition: opacity .25s ease-in-out;
   -moz-transition: opacity .25s ease-in-out;
   -webkit-transition: opacity .25s ease-in-out;
-  &:after {
-    content: '';
+
+  .tooltip-arrow {
     position: absolute;
     width: 10px;
     height: 10px;
@@ -23,37 +29,38 @@
     -ms-transform: rotate(45deg);
     transform: rotate(45deg);
   }
+
   &.invisible{
     opacity: 0;
     pointer-events: none;
   }
 }
 
-.tooltip-frost-popover.bottom:after, .tooltip-frost-popover.bottom-left:after, .tooltip-frost-popover.bottom-right:after {
+.tooltip-frost-popover.bottom .tooltip-arrow, .tooltip-frost-popover.bottom-left .tooltip-arrow, .tooltip-frost-popover.bottom-right .tooltip-arrow {
   top: -1px;
   left: 50%;
-  border-top: solid 1px black;
-  border-left: solid 1px black;
+  border-top: solid 1px $frost-color-lgrey-1;
+  border-left: solid 1px $frost-color-lgrey-1;
 }
 
-.tooltip-frost-popover.right:after, .tooltip-frost-popover.right-top:after, .tooltip-frost-popover.right-bottom:after {
+.tooltip-frost-popover.right .tooltip-arrow, .tooltip-frost-popover.right-top .tooltip-arrow, .tooltip-frost-popover.right-bottom .tooltip-arrow {
   left: -1px;
   top: 50%;
-  border-bottom: solid 1px black;
-  border-left: solid 1px black;
+  border-bottom: solid 1px $frost-color-lgrey-1;
+  border-left: solid 1px $frost-color-lgrey-1;
 }
 
-.tooltip-frost-popover.top:after, .tooltip-frost-popover.top-left:after, .tooltip-frost-popover.top-right:after {
+.tooltip-frost-popover.top .tooltip-arrow, .tooltip-frost-popover.top-left .tooltip-arrow, .tooltip-frost-popover.top-right .tooltip-arrow {
   bottom: -1px;
   left: 50%;
-  border-bottom: solid 1px black;
-  border-right: solid 1px black;
+  border-bottom: solid 1px $frost-color-lgrey-1;
+  border-right: solid 1px $frost-color-lgrey-1;
 }
 
 
-.tooltip-frost-popover.left:after, .tooltip-frost-popover.left-top:after, .tooltip-frost-popover.left-bottom:after {
+.tooltip-frost-popover.left .tooltip-arrow, .tooltip-frost-popover.left-top .tooltip-arrow, .tooltip-frost-popover.left-bottom .tooltip-arrow {
   right: -1px;
   top: 50%;
-  border-top: solid 1px black;
-  border-right: solid 1px black;
+  border-top: solid 1px $frost-color-lgrey-1;
+  border-right: solid 1px $frost-color-lgrey-1;
 }

--- a/addon/templates/components/frost-popover.hbs
+++ b/addon/templates/components/frost-popover.hbs
@@ -1,1 +1,2 @@
 {{yield (action 'close')}}
+<div class='tooltip-arrow' />

--- a/blueprints/ember-frost-popover/index.js
+++ b/blueprints/ember-frost-popover/index.js
@@ -11,7 +11,7 @@ module.exports = {
     return this.addAddonsToProject({
       packages: [
         {name: 'ember-lodash-shim', target: '0.1.4'},
-        {name: 'ember-tooltips', target: '0.5.9'}
+        {name: 'ember-prop-types', target: '2.5.6'}
       ]
     })
   }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,5 @@
 'use strict'
 
 module.exports = {
-  name: 'ember-frost-popover',
-
-  included: function (app) {
-    this._super.included(app)
-  }
+  name: 'ember-frost-popover'
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-load-initializers": "^0.5.0",
     "ember-lodash-shim": "0.1.4",
     "ember-one-way-controls": "1.0.0",
+    "ember-prop-types": "2.5.6",
     "ember-redux": "1.4.0",
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "1.2.0",
@@ -65,10 +66,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-computed-decorators": "^0.2.2",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-sass": "^5.2.0",
-    "liquid-fire": "0.24.1"
+    "ember-cli-sass": "^5.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -37,6 +37,13 @@
   {{/frost-popover}}
 {{/frost-button}}
 
+<p />
+{{#frost-button size='small' priority='primary' class='button-auto' text='Auto'}}
+  {{#frost-popover target='.button-auto' closest=true position='auto left'}}
+    <span class='inside'>This tooltip wants to be on the left, but sadly can't</span>
+  {{/frost-popover}}
+{{/frost-button}}
+
 <h2>Activating Event</h2>
 {{#frost-button size='small' priority='primary' class='event-mouse' text='Mouseenter'}}
   {{#frost-popover target='.event-mouse' closest=true event='mouseenter mouseleave'}}

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -1,63 +1,96 @@
-<div class='target'>
-frost-popover testbed
-</div>
-{{#frost-popover target='.target'}}
-  <span class='inside'>Inside</span>
+<h2>DOM Placements</h2>
+
+{{frost-button size='small' priority='primary' class='sibling' text='Sibling Tooltip'}}
+{{#frost-popover target='.sibling'}}
+  <span class='inside'>This tooltip was alongside the target</span>
 {{/frost-popover}}
 
-<div class='close'>
-closest testbed
-{{#frost-popover target='.close' excludePadding=true closest=true}}
-  <span class='inside'>Closest</span>
-{{/frost-popover}}
-</div>
+{{#frost-button size='small' priority='primary' class='child' text='Child Tooltip'}}
+  {{#frost-popover target='.child' excludePadding=true closest=true}}
+    <span class='inside'>This tooltip was inside</span>
+  {{/frost-popover}}
+{{/frost-button}}
 
-<div class='close'>
-closest testbed
-{{#frost-popover target='.close' excludePadding=true closest=true position='top'}}
-  <span class='inside'>Closest</span>
-{{/frost-popover}}
-</div>
+<h2>Positions</h2>
 
+{{#frost-button size='small' priority='primary' class='button-top' text='Top'}}
+  {{#frost-popover target='.button-top' closest=true position='top'}}
+    <span class='inside'>Tooltip is showing above the target</span>
+  {{/frost-popover}}
+{{/frost-button}}
 
-<div id='foo' class='lefty'>
-left testbed 1
-{{#frost-popover target='#foo' position='right'}}
-  <span class='inside'>left1</span>
-{{/frost-popover}}
-</div>
-<div class='lefty'>
-left testbed 2
-{{#frost-popover target='.lefty' closest=true position='left' excludePadding=true}}
-  <span class='inside'>left 2</span>
-{{/frost-popover}}
-</div>
-<div class='lefty'>
-left testbed 3
-{{#frost-popover target='.lefty' closest=true position='bottom'}}
-  <span class='inside'>left 3</span>
-{{/frost-popover}}
-</div>
-<div class='lefty'>
-left testbed 4
-{{#frost-popover target='.lefty' closest=true position='top'}}
-  <span class='inside'>left 4 left 4 left 4left 4left 4left 4left 4</span>
-{{/frost-popover}}
-</div>
-<div class='lefty'>
-left testbed 5
-{{#frost-popover target='.lefty' closest=true position='right' excludePadding=true event='mouseenter mouseleave'}}
-  <span class='inside'>left 5 left 5left 5left 5left 5left 5left 5left 5left 5left 5</span>
-{{/frost-popover}}
-</div>
+{{#frost-button size='small' priority='primary' class='button-right' text='Right'}}
+  {{#frost-popover target='.button-right' closest=true position='right'}}
+    <span class='inside'>Tooltip is showing to the right of the target</span>
+  {{/frost-popover}}
+{{/frost-button}}
 
+{{#frost-button size='small' priority='primary' class='button-bottom' text='Bottom'}}
+  {{#frost-popover target='.button-bottom' closest=true position='bottom'}}
+    <span class='inside'>Tooltip is showing below the target</span>
+  {{/frost-popover}}
+{{/frost-button}}
 
-{{#frost-button size='small' priority='primary' class='button'}}
-  <div class='text'>Target</div>
+{{#frost-button size='small' priority='primary' class='button-left' text='Left'}}
+  {{#frost-popover target='.button-left' closest=true position='left'}}
+    <span class='inside'>Tooltip is showing to the left of the target</span>
+  {{/frost-popover}}
+{{/frost-button}}
+
+<h2>Activating Event</h2>
+{{#frost-button size='small' priority='primary' class='event-mouse' text='Mouseenter'}}
+  {{#frost-popover target='.event-mouse' closest=true event='mouseenter mouseleave'}}
+    <span class='inside'>Tooltip is toggled on mouse enter and mouse leave</span>
+  {{/frost-popover}}
+{{/frost-button}}
+
+{{#frost-button size='small' priority='primary' class='event-click' text='Click'}}
+  {{#frost-popover target='.event-click' closest=true event='click'}}
+    <span class='inside'>tooltip is toggled on click</span>
+  {{/frost-popover}}
+{{/frost-button}}
+
+<h2>Other Features</h2>
+{{#frost-button size='small' priority='primary' class='button' text='Custom Close'}}
   {{#frost-popover target='.button' closest=true offset=10 position='bottom' as |close|}}
-    Popover content
+    This popover is yielding with a provided close action
     {{#frost-button size="small" priority="tertiary" onClick=(action close)}}
       <div class="text">Close</div>
     {{/frost-button}}
   {{/frost-popover}}
 {{/frost-button}}
+<br />
+{{#frost-button size='small' priority='primary' class='resize-on' text='Resize Enabled'}}
+  {{#frost-popover target='.resize-on' closest=true resize=true position='left'}}
+    <span class='inside'>Extra long content that would require resizing to be visible</span>
+  {{/frost-popover}}
+{{/frost-button}}
+<br />
+{{#frost-button size='small' priority='primary' class='resize-off' text='Resize Disabled'}}
+  {{#frost-popover target='.resize-off' closest=true resize=false position='left'}}
+    <span class='inside'>Extra long content that would require resizing to be visible</span>
+  {{/frost-popover}}
+{{/frost-button}}
+
+<h2>Viewport</h2>
+<div class='viewport'>
+  {{frost-button size='small' priority='primary' class='viewport-left' text='Left'}}
+  {{#frost-popover target='.viewport-left' viewport='.viewport'}}
+    <span class='inside'>Vertical position allows horizontal shift</span>
+  {{/frost-popover}}
+
+  {{frost-button size='small' priority='primary' class='viewport-right' text='Right'}}
+  {{#frost-popover target='.viewport-right' viewport='.viewport' position='top'}}
+    <span class='inside'>Vertical position allows horizontal shift</span>
+  {{/frost-popover}}
+
+  {{frost-button size='small' priority='primary' class='viewport-top' text='Top'}}
+  {{#frost-popover target='.viewport-top' viewport='.viewport' position='left'}}
+    <span class='inside'>Horizontal position allows vertical shift</span>
+  {{/frost-popover}}
+
+  {{frost-button size='small' priority='primary' class='viewport-bottom' text='Bottom'}}
+  {{#frost-popover target='.viewport-bottom' viewport='.viewport' position='right'}}
+    <span class='inside'>Horizontal position allows veritcal shift</span>
+  {{/frost-popover}}
+</div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -10,17 +10,46 @@
   margin: auto;
 }
 
-.middle {
-  margin-left: 50%;
+.dummy-content {
+  position: relative;
 }
+
 .close {
   margin-right: 92%;
-  padding: 10px 0; 
+  padding: 10px 0;
 }
-.target {
-  margin-right: 89%;
+
+.resize-on, .resize-off {
+  margin: 10px 75px;
 }
-.lefty {
-  float: left;
-  padding: 0 10px;
+
+.viewport {
+  position: relative;
+  border: 1px solid black;
+  width: 400px;
+  height: 400px;
+
+  .viewport-left {
+    position: absolute;
+    top: 50%;
+    left: 0;
+  }
+
+  .viewport-right {
+    position: absolute;
+    top: 50%;
+    right: 0;
+  }
+
+  .viewport-top {
+    position: absolute;
+    top: 0;
+    left: 50%;
+  }
+
+  .viewport-bottom {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+  }
 }

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -10,22 +10,13 @@ describeComponent(
   },
   function () {
     it('renders', function () {
-      // Set any properties with this.set('myProperty', 'value')
-      // Handle any actions with this.on('myAction', function (val) { ... })
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#frost-popover}}
-      //     template content
-      //   {{/frost-popover}}
-      // `)
-
       this.render(hbs`
-<div class='target'>
-frost-popover testbed
-</div>
-{{#frost-popover target='.target'}}
-  <span class='inside'>Inside</span>
-{{/frost-popover}}
+        <div class='target'>
+          frost-popover testbed
+        </div>
+        {{#frost-popover target='.target'}}
+          <span class='inside'>Inside</span>
+        {{/frost-popover}}
       `)
       expect(this.$()).to.have.length(1)
     })
@@ -33,21 +24,46 @@ frost-popover testbed
     it('clicks', function (done) {
       this.timeout(5000)
       this.render(hbs`
-<div id='foo' class='target'>
-frost-popover testbed
-</div>
-{{#frost-popover target='#foo'}}
-  <span class='inside'>Inside</span>
-{{/frost-popover}}
+        <div id='foo' class='target'>
+          click test
+        </div>
+        {{#frost-popover target='#foo'}}
+          <span class='inside'>Inside</span>
+        {{/frost-popover}}
       `)
       Ember.run.later(function () {
         this.$('#foo').click()
-      }, 1000)
+
+        Ember.run.later(function () {
+          expect(this.$('.visible')).to.have.length(1)
+          done()
+        }, 100)
+      }, 100)
+    })
+
+    it('constrains to the viewport', function (done) {
+      this.render(hbs`
+        <div id='viewport' style='width: 400px; height: 400px;'>
+          <span id='viewport-test'>
+            viewport test
+          </span>
+          {{#frost-popover target='#viewport-test' viewport='#viewport' position='bottom'}}
+            <span class='inside' style='display: inline-block; width: 100px'>Inside</span>
+          {{/frost-popover}}
+        </div>
+      `)
 
       Ember.run.later(function () {
-        expect(this.$('.visible')).to.have.length(1)
-        done()
-      }, 3000)
+        this.$('#viewport-test').click()
+        Ember.run.later(function () {
+          const viewportRect = this.$('#viewport')[0].getBoundingClientRect()
+          const popoverRect = this.$('.tooltip-frost-popover')[0].getBoundingClientRect()
+
+          expect(this.$('.visible')).to.have.length(1)
+          expect(popoverRect.left >= viewportRect.left).to.equal(true)
+          done()
+        }, 100)
+      }, 100)
     })
   }
 )


### PR DESCRIPTION
This component should now be on par with what `Bootstrap` has to offer. It has support for `viewport` and I brought in @EWhite613's auto positioning changes. This component will also cause *resizing* at the edges so content that was meant to be wrapped can still be visible without steering off the edges. If the *resizing* isn't wanted, which was an annoying problem with `Bootstrap`, you can set the `resize` attribute to false.

I also felt the current styles for this component were out of sync with the other dropdown-like components laying around in our other libraries and I updated it to match what `frost-select` did. The demo was improved and hopefully the code looks more elegant.

#MINOR#