### PR TITLE
Add test to cover passing action through close handler

### DIFF
--- a/tests/unit/components/frost-popover-test.js
+++ b/tests/unit/components/frost-popover-test.js
@@ -1,0 +1,27 @@
+/* jshint expr:true */
+import { expect } from 'chai'
+import {
+  describeComponent,
+  it
+} from 'ember-mocha'
+
+describeComponent(
+  'frost-popover',
+  'FrostPopoverComponent',
+  {
+    // Specify the other units that are required for this test
+    // needs: ['component:foo', 'helper:bar'],
+    unit: true
+  },
+  function () {
+    it('calls passed action while close', function () {
+      let callCounter = 0
+      let forwardedAction = function () {
+        callCounter++
+      }
+      const component = this.subject()
+      component.actions.close.apply(component, [forwardedAction])
+      expect(callCounter).to.be.equal(1)
+    })
+  }
+)


### PR DESCRIPTION
This is a #PATCH# to add a unit test to cover case of passing an action through `close` handler