### PR TITLE
Add missing blueprint dependency

### DIFF
--- a/blueprints/ember-frost-popover/index.js
+++ b/blueprints/ember-frost-popover/index.js
@@ -10,6 +10,7 @@ module.exports = {
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [
+        {name: 'ember-frost-core', target: '0.29.1'},
         {name: 'ember-lodash-shim', target: '0.1.4'},
         {name: 'ember-prop-types', target: '^3.0.0'}
       ]


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** `ember-frost-core` to blueprints.

