### PR TITLE
Remove one way control

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-hook": "^1.3.5",
     "ember-load-initializers": "^0.5.0",
     "ember-lodash-shim": "0.1.4",
-    "ember-one-way-controls": "1.0.0",
     "ember-prop-types": "^3.0.0",
     "ember-redux": "1.4.0",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Removed** `ember-one-way-controls`

