### PR TITLE
update unit and integration tests to not use deprecated describeComponent()

### DIFF
--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -1,71 +1,69 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {$, run} = Ember
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-popover',
-  'Integration: EmberFrostPopoverComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      this.render(hbs`
-        <div class='target'>
-          frost-popover testbed
-        </div>
-        {{#frost-popover target='.target'}}
-          <span class='inside'>Inside</span>
-        {{/frost-popover}}
-      `)
-      expect(this.$()).to.have.length(1)
-    })
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-    it('clicks', function (done) {
-      this.timeout(5000)
-      this.render(hbs`
-        <div id='foo' class='target'>
-          click test
-        </div>
-        {{#frost-popover target='#foo'}}
-          <span class='inside'>Inside</span>
-        {{/frost-popover}}
-      `)
-      run.later(function () {
-        $('#foo').click()
+const test = integration('frost-popover')
+describe(test.label, function () {
+  test.setup()
 
-        run.later(function () {
-          expect($('.visible')).to.have.length(1)
-          done()
-        }, 100)
-      }, 100)
-    })
+  it('renders', function () {
+    this.render(hbs`
+      <div class='target'>
+        frost-popover testbed
+      </div>
+      {{#frost-popover target='.target'}}
+        <span class='inside'>Inside</span>
+      {{/frost-popover}}
+    `)
+    expect(this.$()).to.have.length(1)
+  })
 
-    it('constrains to the viewport', function (done) {
-      this.render(hbs`
-        <div id='viewport' style='width: 400px; height: 400px;'>
-          <span id='viewport-test'>
-            viewport test
-          </span>
-          {{#frost-popover target='#viewport-test' viewport='#viewport' position='bottom'}}
-            <span class='inside' style='display: inline-block; width: 100px'>Inside</span>
-          {{/frost-popover}}
-        </div>
-      `)
+  it('clicks', function (done) {
+    this.timeout(5000)
+    this.render(hbs`
+      <div id='foo' class='target'>
+        click test
+      </div>
+      {{#frost-popover target='#foo'}}
+        <span class='inside'>Inside</span>
+      {{/frost-popover}}
+    `)
+    run.later(function () {
+      $('#foo').click()
 
       run.later(function () {
-        $('#viewport-test').click()
-        run.later(function () {
-          const viewportRect = $('#viewport')[0].getBoundingClientRect()
-          const popoverRect = $('.tooltip-frost-popover')[0].getBoundingClientRect()
-
-          expect($('.visible')).to.have.length(1)
-          expect(popoverRect.left >= viewportRect.left).to.equal(true)
-          done()
-        }, 100)
+        expect($('.visible')).to.have.length(1)
+        done()
       }, 100)
-    })
-  }
-)
+    }, 100)
+  })
+
+  it('constrains to the viewport', function (done) {
+    this.render(hbs`
+      <div id='viewport' style='width: 400px; height: 400px;'>
+        <span id='viewport-test'>
+          viewport test
+        </span>
+        {{#frost-popover target='#viewport-test' viewport='#viewport' position='bottom'}}
+          <span class='inside' style='display: inline-block; width: 100px'>Inside</span>
+        {{/frost-popover}}
+      </div>
+    `)
+
+    run.later(function () {
+      $('#viewport-test').click()
+      run.later(function () {
+        const viewportRect = $('#viewport')[0].getBoundingClientRect()
+        const popoverRect = $('.tooltip-frost-popover')[0].getBoundingClientRect()
+
+        expect($('.visible')).to.have.length(1)
+        expect(popoverRect.left >= viewportRect.left).to.equal(true)
+        done()
+      }, 100)
+    }, 100)
+  })
+})

--- a/tests/unit/components/frost-popover-test.js
+++ b/tests/unit/components/frost-popover-test.js
@@ -1,27 +1,20 @@
 /* jshint expr:true */
 import {expect} from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'frost-popover',
-  'FrostPopoverComponent',
-  {
-    // Specify the other units that are required for this test
-    // needs: ['component:foo', 'helper:bar'],
-    unit: true
-  },
-  function () {
-    it('calls passed action while close', function () {
-      let callCounter = 0
-      let forwardedAction = function () {
-        callCounter++
-      }
-      const component = this.subject()
-      component.actions.close.apply(component, [forwardedAction])
-      expect(callCounter).to.be.equal(1)
-    })
-  }
-)
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('frost-popover')
+describe(test.label, function () {
+  test.setup()
+
+  it('calls passed action while close', function () {
+    let callCounter = 0
+    let forwardedAction = function () {
+      callCounter++
+    }
+    const component = this.subject()
+    component.actions.close.apply(component, [forwardedAction])
+    expect(callCounter).to.be.equal(1)
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-popover/issues/23
# CHANGELOG
* **Updated** integration and unit tests to remove the deprecated use of `describeComponent()`
