### PR TITLE
Update to new linting functionality

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/README.md
+++ b/README.md
@@ -57,11 +57,17 @@ ember install ember-frost-popover
 
 ## Specifying Target
 
-If the `frost-popover` component is placed next to the `target`, be careful to use a selector that will uniquely identify the `target`. If it is nested inside the `target`, you can set `closest` to true which will search the nearest ancestor from the `popover`.
+If the `frost-popover` component is placed next to the `target`, be careful to use a selector that will uniquely
+identify the `target`. If it is nested inside the `target`, you can set `closest` to true which will search the
+nearest ancestor from the `popover`.
 
 ### A Note On Positioning
 
-The `popover` is displayed using `absolute` positioning. The `target`'s coordinates are determined from the `offsets` from its parent's container. In most cases, the `target` will occupy the same stacking context as the `popover`. However, if the `target` has `absolute` positioning and the `popover` is nested, they won't share the same stacking context and the `popover`'s position will be erroneous. If the `target` must be `absolute`, then it's best to place the `popover` next to it.
+The `popover` is displayed using `absolute` positioning. The `target`'s coordinates are determined from the `offsets`
+from its parent's container. In most cases, the `target` will occupy the same stacking context as the `popover`.
+However, if the `target` has `absolute` positioning and the `popover` is nested, they won't share the same stacking
+context and the `popover`'s position will be erroneous. If the `target` must be `absolute`, then it's best to place
+the `popover` next to it.
 
 **template.hbs**
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,10 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "eslint": "eslint *.js addon app blueprints config tests --fix",
-    "md-lint": "remark *.md",
-    "sass-lint": "sass-lint -q -v"
+    "lint": "lint-all-the-things",
+    "start": "ember server",
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-popover.git",
   "engines": {
@@ -53,13 +50,9 @@
     "ember-resolver": "^2.1.1",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.1",
-    "ember-test-utils": "^1.6.1",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.14.0",
-    "eslint-config-frost-standard": "^5.3.2",
-    "loader.js": "^4.1.0",
-    "remark-cli": "^2.1.0",
-    "sass-lint": "^1.10.2"
+    "loader.js": "^4.1.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-popover/issues/27

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.