### PR TITLE
Added an onDisplay and onHide function parameters to be run after the toggle is pressed

### DIFF
--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {$, Component, run, isPresent, typeOf} = Ember
+const {$, Component, isPresent, run, typeOf} = Ember
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-popover'
@@ -18,14 +18,14 @@ export default Component.extend(PropTypeMixin, {
     excludePadding: PropTypes.bool,
     index: PropTypes.number,
     offset: PropTypes.number,
+    onToggle: PropTypes.func,
     position: PropTypes.string,
     resize: PropTypes.bool,
     viewport: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
       PropTypes.func
-    ]),
-    onToggle: PropTypes.func
+    ])
   },
 
   getDefaultProps () {

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -25,7 +25,7 @@ export default Component.extend(PropTypeMixin, {
       PropTypes.object,
       PropTypes.func
     ]),
-    onToggle: PropTypes.object
+    onToggle: PropTypes.func
   },
 
   getDefaultProps () {

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -18,7 +18,8 @@ export default Component.extend(PropTypeMixin, {
     excludePadding: PropTypes.bool,
     index: PropTypes.number,
     offset: PropTypes.number,
-    onToggle: PropTypes.func,
+    onDisplay: PropTypes.func,
+    onHide: PropTypes.func,
     position: PropTypes.string,
     resize: PropTypes.bool,
     viewport: PropTypes.oneOfType([
@@ -369,13 +370,13 @@ export default Component.extend(PropTypeMixin, {
           marginTop: -delta.top - arrowMargin
         })
 
-        if (isPresent(this.get('onToggle'))) {
-          this.get('onToggle')(this.get('visible'))
+        if (isPresent(this.get('onDisplay'))) {
+          this.get('onDisplay')()
         }
       } else {
         this.unregisterClickOff()
-        if (isPresent(this.get('onToggle'))) {
-          this.get('onToggle')(this.get('visible'))
+        if (isPresent(this.get('onHide'))) {
+          this.get('onHide')()
         }
       }
     }

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {$, Component, run, typeOf} = Ember
+const {$, Component, run, isPresent, typeOf} = Ember
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-popover'
@@ -24,7 +24,8 @@ export default Component.extend(PropTypeMixin, {
       PropTypes.string,
       PropTypes.object,
       PropTypes.func
-    ])
+    ]),
+    onToggle: PropTypes.object
   },
 
   getDefaultProps () {
@@ -367,8 +368,15 @@ export default Component.extend(PropTypeMixin, {
           marginLeft: -delta.left - arrowMargin,
           marginTop: -delta.top - arrowMargin
         })
+
+        if (isPresent(this.get('onToggle'))) {
+          this.get('onToggle')(this.get('visible'))
+        }
       } else {
         this.unregisterClickOff()
+        if (isPresent(this.get('onToggle'))) {
+          this.get('onToggle')(this.get('visible'))
+        }
       }
     }
   }

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -1,5 +1,11 @@
 import Ember from 'ember'
-const {Controller} = Ember
+const {$, Controller} = Ember
 
 export default Controller.extend({
+  actions: {
+    onToggle: function (toggle) {
+      const text = toggle ? 'Toggle is on' : 'Toggle is off'
+      $('.on-toggle-content').text(text)
+    }
+  }
 })

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -3,9 +3,11 @@ const {$, Controller} = Ember
 
 export default Controller.extend({
   actions: {
-    onToggle: function (toggle) {
-      const text = toggle ? 'Toggle is on' : 'Toggle is off'
-      $('.on-toggle-content').text(text)
+    onDisplay: function () {
+      $('.toggle-functions-content').text('A scary monster is terrorizing the village!!')
+    },
+    onHide: function () {
+      $('.toggle-functions-content').text('The scary monster has been vanquished!')
     }
   }
 })

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -101,3 +101,12 @@
     <span class='inside'>Horizontal position allows veritcal shift</span>
   {{/frost-popover}}
 </div>
+
+<h2>onToggle</h2>
+<div class='on-toggle'>
+  <div class='on-toggle-content'>Toggle content will appear here when clicked</div>
+  {{frost-button hook='onToggle' size='small' priority='primary' class='on-toggle-button' text='Toggle function'}}
+  {{#frost-popover target='.on-toggle-button' onToggle=(action 'onToggle')}}
+    <span class='toggle-content'>The toggle text should be 'on'!</span>
+  {{/frost-popover}}
+</div>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -102,11 +102,11 @@
   {{/frost-popover}}
 </div>
 
-<h2>onToggle</h2>
-<div class='on-toggle'>
-  <div class='on-toggle-content'>Toggle content will appear here when clicked</div>
-  {{frost-button hook='onToggle' size='small' priority='primary' class='on-toggle-button' text='Toggle function'}}
-  {{#frost-popover target='.on-toggle-button' onToggle=(action 'onToggle')}}
-    <span class='toggle-content'>The toggle text should be 'on'!</span>
+<h2>Toggle functions</h2>
+<div class='toggle-functions'>
+  <div class='toggle-functions-content'>Content will appear here when clicked</div>
+  {{frost-button hook='toggle-functions-button' size='small' priority='primary' class='toggle-functions-button' text='Toggle action'}}
+  {{#frost-popover target='.toggle-functions-button' onDisplay=(action 'onDisplay') onHide=(action 'onHide')}}
+    <span class='toggle-content'>Scary monster! RAWRR!</span>
   {{/frost-popover}}
 </div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -54,3 +54,9 @@
     left: 50%;
   }
 }
+
+.on-toggle {
+  .on-toggle-content {
+    padding-bottom: 10px;
+  }
+}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -55,8 +55,8 @@
   }
 }
 
-.on-toggle {
-  .on-toggle-content {
+.toggle-functions {
+  .toggle-functions-content {
     padding-bottom: 10px;
   }
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** onDisplay function to be run after when the popover is made visible.
* **Added** onHide function to be run after when the popover is no longer visible.
