### PR TITLE
onDisplay and onHide now pass the current object as a parameter

### DIFF
--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -371,12 +371,12 @@ export default Component.extend(PropTypeMixin, {
         })
 
         if (isPresent(this.get('onDisplay'))) {
-          this.get('onDisplay')()
+          this.get('onDisplay')(this)
         }
       } else {
         this.unregisterClickOff()
         if (isPresent(this.get('onHide'))) {
-          this.get('onHide')()
+          this.get('onHide')(this)
         }
       }
     }


### PR DESCRIPTION
I want to resolve #44 by passing in the current object so the component I am creating which extends this one. This descendant component will provide an onDisplay and onHide by default and requires the context of this component. So, I will pass 'this' as an argument so my onDisplay and onHide functions will have the context. 

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Modified** onDisplay and onHide now pass the current object as a parameter
