### PR TITLE
Add feature handlerIn and handlerOut to fix hover use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ ember install ember-frost-popover
 | Option | `closest` | boolean  | When true uses JQuery's [closest function](https://api.jquery.com/closest/). Otherwise just uses main selector `$(<target>)` (defaults to `false`).  |
 | Option | `excludePadding` | boolean  | When true removes the padding from position calculations (defaults to `false`).|
 | Option | `event` |  | The event that will trigger the popover (defaults to on `click`). Uses [on()](http://api.jquery.com/on/)|
+| Option | `handlerIn` |  | The event that will open the popover (replaces the `event` when `handlerOut` is also set). Uses [on()](http://api.jquery.com/on/)|
+| Option | `handlerOut` |  | The event that will close the popover (replaces the `event` when `handlerIn` is also set). Uses [on()](http://api.jquery.com/on/)|
 | Option | `target` |  | The selector string of the target that activates the popover |
 | Option | `viewport`| | The selector for the viewport. Defaults to 'body' |
 | Option | `resize` | | If set to false, will prevent the browser from resizing at the edges of the viewport. This preserves the *expand to fit content* behavior of `width: auto`. It defaults to true. |

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -50,14 +50,14 @@ export default Component.extend(PropTypeMixin, {
     const target = this.getTarget()
     const event = this.get('event')
     const handlerIn = this.get('handlerIn')
-    const handlerOut =this.get('handlerOut')
-    if (handlerIn && handlerOut){ 
+    const handlerOut = this.get('handlerOut')
+    if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-          if (!this.get('visible')){
+          if (!this.get('visible')) {
             this.togglePopover(event)
           }
         })
@@ -67,24 +67,24 @@ export default Component.extend(PropTypeMixin, {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-          if (this.get('visible')){
+          if (this.get('visible')) {
             this.togglePopover(event)
           }
         })
       }
       $(target).on(handlerIn, this._eventHandlerIn)
       $(target).on(handlerOut, this._eventHandlerOut)
-    } else{
+    } else {
       this._eventHandler = (event) => {
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-  
+
           this.togglePopover(event)
         })
       }
-  
+
       $(target).on(event, this._eventHandler)
     }
   },
@@ -93,7 +93,7 @@ export default Component.extend(PropTypeMixin, {
     const target = this.getTarget()
     const event = this.get('event')
     const handlerIn = this.get('handlerIn')
-    const handlerOut =this.get('handlerOut')
+    const handlerOut = this.get('handlerOut')
     if (handlerIn && handlerOut) {
       $(target).off(handlerIn, this._eventHandlerIn)
       $(target).off(handlerOut, this._eventHandlerOut)

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -16,6 +16,8 @@ export default Component.extend(PropTypeMixin, {
     closest: PropTypes.bool,
     event: PropTypes.string,
     excludePadding: PropTypes.bool,
+    handlerIn: PropTypes.string,
+    handlerOut: PropTypes.string,
     index: PropTypes.number,
     offset: PropTypes.number,
     onDisplay: PropTypes.func,
@@ -47,24 +49,57 @@ export default Component.extend(PropTypeMixin, {
   didInsertElement () {
     const target = this.getTarget()
     const event = this.get('event')
-
-    this._eventHandler = (event) => {
-      run.next(() => {
-        if (this.isDestroyed || this.isDestroying) {
-          return
-        }
-
-        this.togglePopover(event)
-      })
+    const handlerIn = this.get('handlerIn')
+    const handlerOut =this.get('handlerOut')
+    if (handlerIn && handlerOut){ 
+      this._eventHandlerIn = (event) => {
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
+          }
+          if (!this.get('visible')){
+            this.togglePopover(event)
+          }
+        })
+      }
+      this._eventHandlerOut = (event) => {
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
+          }
+          if (this.get('visible')){
+            this.togglePopover(event)
+          }
+        })
+      }
+      $(target).on(handlerIn, this._eventHandlerIn)
+      $(target).on(handlerOut, this._eventHandlerOut)
+    } else{
+      this._eventHandler = (event) => {
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
+          }
+  
+          this.togglePopover(event)
+        })
+      }
+  
+      $(target).on(event, this._eventHandler)
     }
-
-    $(target).on(event, this._eventHandler)
   },
 
   willDestroyElement () {
     const target = this.getTarget()
     const event = this.get('event')
-    $(target).off(event, this._eventHandler)
+    const handlerIn = this.get('handlerIn')
+    const handlerOut =this.get('handlerOut')
+    if (handlerIn && handlerOut) {
+      $(target).off(handlerIn, this._eventHandlerIn)
+      $(target).off(handlerOut, this._eventHandlerOut)
+    } else {
+      $(target).off(event, this._eventHandler)
+    }
     this.unregisterClickOff()
   },
 

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -46,7 +46,7 @@
 
 <h2>Activating Event</h2>
 {{#frost-button hook='mouseEnterButton' size='small' priority='primary' class='event-mouse' text='Mouseenter'}}
-  {{#frost-popover target='.event-mouse' closest=true event='mouseenter mouseleave'}}
+  {{#frost-popover target='.event-mouse' closest=true handlerIn='mouseenter' handlerOut='mouseleave'}}
     <span class='inside'>Tooltip is toggled on mouse enter and mouse leave</span>
   {{/frost-popover}}
 {{/frost-button}}

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -42,6 +42,34 @@ describe(test.label, function () {
     }, 100)
   })
 
+  it('test handlerIn and handlerOut', function (done) {
+    this.timeout(5000)
+    this.render(hbs`
+      <div id='foo' class='target'>
+        click test
+      </div>
+      {{#frost-popover target='#foo' handlerIn='mouseenter' handlerOut='mouseleave'}}
+        <span class='inside'>Inside</span>
+      {{/frost-popover}}
+    `)
+    run.later(function () {
+      $('#foo').mouseenter()
+
+      run.later(function () {
+        expect($('.visible')).to.have.length(1)
+        $('#foo').mouseenter()
+        run.later(function () {
+          expect($('.visible')).to.have.length(1)
+          $('#foo').mouseleave()
+          run.later(function () {
+            expect($('.visible')).to.have.length(0)
+            done()
+          }, 100)
+        }, 100)
+      }, 100)
+    }, 100)
+  })
+
   it('constrains to the viewport', function (done) {
     this.render(hbs`
       <div id='viewport' style='width: 400px; height: 400px;'>

--- a/tests/unit/components/frost-popover-test.js
+++ b/tests/unit/components/frost-popover-test.js
@@ -29,7 +29,7 @@ describe(test.label, function () {
     component.actions.close.apply(component, [forwardedAction])
     expect(callCounter).to.be.equal(1)
   })
-  describe('handlers In and Out', function(){
+  describe('handlers In and Out', function () {
     beforeEach(function () {
       sandbox.spy($.fn, 'on')
       sandbox.spy($.fn, 'off')

--- a/tests/unit/components/frost-popover-test.js
+++ b/tests/unit/components/frost-popover-test.js
@@ -29,7 +29,51 @@ describe(test.label, function () {
     component.actions.close.apply(component, [forwardedAction])
     expect(callCounter).to.be.equal(1)
   })
+  describe('handlers In and Out', function(){
+    beforeEach(function () {
+      sandbox.spy($.fn, 'on')
+      sandbox.spy($.fn, 'off')
+      component = this.subject({
+        handlerIn: 'mouseenter',
+        handlerOut: 'mouseleave'
+      })
+      sandbox.spy(component, 'togglePopover')
+      sandbox.spy(component, 'closePopover')
+      component.didInsertElement()
+    })
+    it('registers event', function () {
+      expect($.fn.on.firstCall).to.have.been.calledWith('mouseenter', component._eventHandlerIn)
+      expect($.fn.on.secondCall).to.have.been.calledWith('mouseleave', component._eventHandlerOut)
+    })
 
+    it('unregisters event', function () {
+      component.willDestroyElement()
+      expect($.fn.off.firstCall).to.have.been.calledWith('mouseenter', component._eventHandlerIn)
+      expect($.fn.off.secondCall).to.have.been.calledWith('mouseleave', component._eventHandlerOut)
+    })
+
+    it('does not call togglePopover when component is destroyed', function () {
+      run(() => {
+        const eventHandlerIn = component._eventHandlerIn
+        const eventHandlerOut = component._eventHandlerOut
+        component.destroy()
+        eventHandlerIn()
+        expect(component.togglePopover).to.have.callCount(0)
+        eventHandlerOut()
+        expect(component.togglePopover).to.have.callCount(0)
+      })
+    })
+
+    it('does not call closePopover when component is destroyed', function () {
+      run(() => {
+        component.destroy()
+        component.registerClickOff()
+        const eventHandler = $.fn.on.lastCall.args[1]
+        eventHandler()
+        expect(component.closePopover).to.have.callCount(0)
+      })
+    })
+  })
   describe('event handlers', function () {
     beforeEach(function () {
       sandbox.spy($.fn, 'on')


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Add `handlerIn` and `handlerOut` options that override `event`.
  * Fixes hover use case and mirrors JQuery's `.hover()` https://api.jquery.com/hover/
