### PR TITLE
stop propagation feauture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 6.0.0 (2017-11-02)
+
+## WARNING: THIS REVERTS EMBER CLI 2.16.2 BACK TO 2.12.3
+
+We apologize for this change. Unfortunately, due to the internal needs of our organization this became a required action.
+
+The 2.16.2 changes are now located in the `ember-cli-2.16.2` branch and will hopefully be contained in a versioned release again in the future.
+
+# 5.0.0 (2017-10-25)
+* **Updated** to Ember CLI 2.16.2 and babel 6
+* **Updated** to using ember-decorators which replaces ember-computed-decorators
+* **Updated** dependencies
+* **Updated** pr-bumber to version 3
+* **Updated** CONTRIBUTING.md file
+* **Updated** to using Ember Javascript Modules API https://github.com/ember-cli/ember-rfc176-data
+* **Updated** blueprints to latest versions of dependencies
+* **Updated** to use chrome headless in Travis CI
+* **Updated** to using Node 8.1.2 NPM 5
+* **Added** eslint-plugin-ember to enforce Ember Javascript Modules API syntax
+* **Removed** running of code coverage until issue is resolved with ember-cli-code-coverage: https://github.com/kategengler/ember-cli-code-coverage/issues/133
+* **Removed** running of ember-try its-2.12 scenario until issue is resolved: https://github.com/ember-cli/ember-try/issues/148
+
 # 4.4.1 (2017-10-23)
 * **Updated** testing dependencies
 * **Removed** no longer needed `bower.json` and `.bowerrc`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ ember install ember-frost-popover
 | Option | `target` |  | The selector string of the target that activates the popover |
 | Option | `viewport`| | The selector for the viewport. Defaults to 'body' |
 | Option | `resize` | | If set to false, will prevent the browser from resizing at the edges of the viewport. This preserves the *expand to fit content* behavior of `width: auto`. It defaults to true. |
+| Option | `stopPropagation` | | If set to true event handlers will call `event.stopPropagation()` |
 | Option | `delay` | number | Delay the open of the popover if provided, unit in ms.|
 
 ## Specifying Target

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -60,13 +60,12 @@ export default Component.extend(PropTypeMixin, {
     const event = this.get('event')
     const handlerIn = this.get('handlerIn')
     const handlerOut = this.get('handlerOut')
+    const stopPropagation = this.get('stopPropagation')
     if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
-        run(() => {
-          if (this.get('stopPropagation')) {
-            event.stopPropagation()
-          }
-        })
+        if (stopPropagation) {
+          event.stopPropagation()
+        }
         // eslint-disable-next-line complexity
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {
@@ -84,11 +83,9 @@ export default Component.extend(PropTypeMixin, {
       }
 
       this._eventHandlerOut = (event) => {
-        run(() => {
-          if (this.get('stopPropagation')) {
-            event.stopPropagation()
-          }
-        })
+        if (stopPropagation) {
+          event.stopPropagation()
+        }
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
@@ -103,11 +100,9 @@ export default Component.extend(PropTypeMixin, {
       $(target).on(handlerOut, this._eventHandlerOut)
     } else {
       this._eventHandler = (event) => {
-        run(() => {
-          if (this.get('stopPropagation')) {
-            event.stopPropagation()
-          }
-        })
+        if (stopPropagation) {
+          event.stopPropagation()
+        }
         // eslint-disable-next-line complexity
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -62,13 +62,15 @@ export default Component.extend(PropTypeMixin, {
     const handlerOut = this.get('handlerOut')
     if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
-      // eslint-disable-next-line complexity
         run(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return
-          }
           if (this.get('stopPropagation')) {
             event.stopPropagation()
+          }
+        })
+        // eslint-disable-next-line complexity
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
           }
           if (!this.get('visible')) {
             const delay = this.get('delay')
@@ -83,11 +85,13 @@ export default Component.extend(PropTypeMixin, {
 
       this._eventHandlerOut = (event) => {
         run(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return
-          }
           if (this.get('stopPropagation')) {
             event.stopPropagation()
+          }
+        })
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
           }
           run.cancel(this.get('_showDelay'))
           if (this.get('visible')) {
@@ -99,13 +103,15 @@ export default Component.extend(PropTypeMixin, {
       $(target).on(handlerOut, this._eventHandlerOut)
     } else {
       this._eventHandler = (event) => {
-        // eslint-disable-next-line complexity
         run(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return
-          }
           if (this.get('stopPropagation')) {
             event.stopPropagation()
+          }
+        })
+        // eslint-disable-next-line complexity
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
           }
           const delay = this.get('delay')
           if (delay) {

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -25,6 +25,7 @@ export default Component.extend(PropTypeMixin, {
     onHide: PropTypes.func,
     position: PropTypes.string,
     resize: PropTypes.bool,
+    stopPropagation: PropTypes.bool,
     viewport: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
@@ -41,6 +42,7 @@ export default Component.extend(PropTypeMixin, {
       offset: 10,
       position: 'bottom',
       resize: true,
+      stopPropagation: false,
       viewport: 'body',
       visible: false,
       autoPosition: 'bottom'
@@ -60,11 +62,14 @@ export default Component.extend(PropTypeMixin, {
     const handlerOut = this.get('handlerOut')
     if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
-        run.next(() => {
+      // eslint-disable-next-line complexity
+        run(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-
+          if (this.get('stopPropagation')) {
+            event.stopPropagation()
+          }
           if (!this.get('visible')) {
             const delay = this.get('delay')
             if (delay) {
@@ -77,11 +82,13 @@ export default Component.extend(PropTypeMixin, {
       }
 
       this._eventHandlerOut = (event) => {
-        run.next(() => {
+        run(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-
+          if (this.get('stopPropagation')) {
+            event.stopPropagation()
+          }
           run.cancel(this.get('_showDelay'))
           if (this.get('visible')) {
             this.togglePopover(event)
@@ -92,11 +99,14 @@ export default Component.extend(PropTypeMixin, {
       $(target).on(handlerOut, this._eventHandlerOut)
     } else {
       this._eventHandler = (event) => {
-        run.next(() => {
+        // eslint-disable-next-line complexity
+        run(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-
+          if (this.get('stopPropagation')) {
+            event.stopPropagation()
+          }
           const delay = this.get('delay')
           if (delay) {
             if (!this.get('visible')) {

--- a/blueprints/ember-frost-popover/index.js
+++ b/blueprints/ember-frost-popover/index.js
@@ -3,7 +3,7 @@ const blueprintHelper = require('ember-frost-core/blueprint-helper')
 module.exports = {
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '1.23.10'}
+      {name: 'ember-frost-core', target: '3.0.0'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/blueprints/ember-frost-popover/index.js
+++ b/blueprints/ember-frost-popover/index.js
@@ -3,7 +3,7 @@ const blueprintHelper = require('ember-frost-core/blueprint-helper')
 module.exports = {
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '3.0.0'}
+      {name: 'ember-frost-core', target: '^3.0.0'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-frost-popover",
-  "version": "4.4.1",
+  "version": "6.0.0",
   "description": "Popping over stuff.",
   "directories": {
     "doc": "doc",
@@ -48,11 +48,11 @@
     "ember-frost-test": "^2.1.2",
     "ember-hook": "^1.4.2",
     "ember-load-initializers": "^0.6.0",
-    "ember-prop-types": "^3.14.1",
+    "ember-prop-types": "^5.0.1",
     "ember-resolver": "^2.1.1",
     "ember-sinon": "^0.7.0",
     "ember-source": "~2.12.0",
-    "ember-spread": "^1.2.2",
+    "ember-spread": "^3.0.0",
     "ember-test-utils": "^6.0.0",
     "ember-truth-helpers": "^1.3.0",
     "loader.js": "^4.2.3",
@@ -66,7 +66,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
-    "ember-frost-core": "1.23.10"
+    "ember-frost-core": "3.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
-    "ember-frost-core": "3.0.0"
+    "ember-frost-core": "^3.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -124,3 +124,16 @@
     <span class='toggle-content'>Scary monster! RAWRR!</span>
   {{/frost-popover}}
 </div>
+
+<h2>Event Propogation</h2>
+<div class='event-propogation-container' onclick="alert('Propgated')" style="position: relative;">
+   {{frost-button hook='propogateButton' size='small' priority='primary' class='propogate' text='Allow Propogation'}}
+  {{#frost-popover target='.propogate' position='auto'}}
+    <span class='inside'>Allowed Propogation</span>
+  {{/frost-popover}}
+   {{#frost-button hook='stopPropogateButton' size='small' priority='primary' class='stop-propogate' text='Stop Propogation'}}
+    {{#frost-popover target='.stop-propogate' position='auto' closest=true stopPropagation=true}}
+      <span class='inside'>Stopped Propogation</span>
+    {{/frost-popover}}
+  {{/frost-button}}
+</div>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -127,11 +127,11 @@
 
 <h2>Event Propogation</h2>
 <div class='event-propogation-container' onclick="alert('Propgated')" style="position: relative;">
-   {{frost-button hook='propogateButton' size='small' priority='primary' class='propogate' text='Allow Propogation'}}
+  {{frost-button hook='propogateButton' size='small' priority='primary' class='propogate' text='Allow Propogation'}}
   {{#frost-popover target='.propogate' position='auto'}}
     <span class='inside'>Allowed Propogation</span>
   {{/frost-popover}}
-   {{#frost-button hook='stopPropogateButton' size='small' priority='primary' class='stop-propogate' text='Stop Propogation'}}
+  {{#frost-button hook='stopPropogateButton' size='small' priority='primary' class='stop-propogate' text='Stop Propogation'}}
     {{#frost-popover target='.stop-propogate' position='auto' closest=true stopPropagation=true}}
       <span class='inside'>Stopped Propogation</span>
     {{/frost-popover}}

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -161,7 +161,8 @@ describe(test.label, function () {
     })
     this.render(hbs`
     <div class='event-propogation-container' onclick={{action spy}} style="position: relative;">
-        {{frost-button hook='propogateButton' size='small' priority='primary' class='propogate' text='Allow Propogation'}}
+        {{frost-button hook='propogateButton' size='small' priority='primary' 
+          class='propogate' text='Allow Propogation'}}
         {{#frost-popover target='.propogate' position='auto'}}
           <span class='inside'>Allowed Propogation</span>
         {{/frost-popover}}
@@ -181,7 +182,8 @@ describe(test.label, function () {
     this.setProperties({spy})
     this.render(hbs`
     <div class='event-propogation-container' onclick={{action spy}} style="position: relative;">
-    {{#frost-button hook='stopPropogateButton' size='small' priority='primary' class='stop-propogate' text='Stop Propogation'}}
+    {{#frost-button hook='stopPropogateButton' size='small' priority='primary' 
+      class='stop-propogate' text='Stop Propogation'}}
     {{#frost-popover target='.stop-propogate' position='auto' closest=true stopPropagation=true}}
       <span class='inside'>Stopped Propogation</span>
     {{/frost-popover}}

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -4,6 +4,7 @@ const {$, run} = Ember
 import {integration} from 'ember-test-utils/test-support/setup-component-test'
 import hbs from 'htmlbars-inline-precompile'
 import {beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
 
 const test = integration('frost-popover')
 describe(test.label, function () {
@@ -150,6 +151,49 @@ describe(test.label, function () {
         expect(popoverRect.left >= viewportRect.left).to.equal(true)
         done()
       }, 100)
+    }, 100)
+  })
+
+  it('should propogate event by default', function (done) {
+    let spy = sinon.spy()
+    this.set('spy', () => {
+      spy()
+    })
+    this.render(hbs`
+    <div class='event-propogation-container' onclick={{action spy}} style="position: relative;">
+        {{frost-button hook='propogateButton' size='small' priority='primary' class='propogate' text='Allow Propogation'}}
+        {{#frost-popover target='.propogate' position='auto'}}
+          <span class='inside'>Allowed Propogation</span>
+        {{/frost-popover}}
+   </div>
+    `)
+    run.later(() => {
+      $('.propogate').click()
+      run.later(() => {
+        expect(spy.callCount).to.gte(1)
+        done()
+      }, 200)
+    }, 100)
+  })
+
+  it('should not propogate event when stopPropagation=true', function (done) {
+    let spy = sinon.spy()
+    this.setProperties({spy})
+    this.render(hbs`
+    <div class='event-propogation-container' onclick={{action spy}} style="position: relative;">
+    {{#frost-button hook='stopPropogateButton' size='small' priority='primary' class='stop-propogate' text='Stop Propogation'}}
+    {{#frost-popover target='.stop-propogate' position='auto' closest=true stopPropagation=true}}
+      <span class='inside'>Stopped Propogation</span>
+    {{/frost-popover}}
+  {{/frost-button}}
+   </div>
+    `)
+    run.later(() => {
+      $('.propogate').click()
+      run.later(() => {
+        expect(spy.callCount).to.equal(0)
+        done()
+      }, 200)
     }, 100)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Add `event.stopPropagation()` option to popover
