### PR TITLE
Bring in #54 to 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ ember install ember-frost-popover
 | Option | `target` |  | The selector string of the target that activates the popover |
 | Option | `viewport`| | The selector for the viewport. Defaults to 'body' |
 | Option | `resize` | | If set to false, will prevent the browser from resizing at the edges of the viewport. This preserves the *expand to fit content* behavior of `width: auto`. It defaults to true. |
+| Option | `stopPropagation` | | If set to true event handlers will call `event.stopPropagation()` |
 | Option | `delay` | number | Delay the open of the popover if provided, unit in ms.|
 
 ## Specifying Target

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -62,13 +62,12 @@ export default Component.extend(PropTypeMixin, {
     const event = this.get('event')
     const handlerIn = this.get('handlerIn')
     const handlerOut = this.get('handlerOut')
+    const stopPropagation = this.get('stopPropagation')
     if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
-        run(() => {
-          if (this.get('stopPropagation')) {
-            event.stopPropagation()
-          }
-        })
+        if (stopPropagation) {
+          event.stopPropagation()
+        }
         // eslint-disable-next-line complexity
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {
@@ -86,11 +85,9 @@ export default Component.extend(PropTypeMixin, {
       }
 
       this._eventHandlerOut = (event) => {
-        run(() => {
-          if (this.get('stopPropagation')) {
-            event.stopPropagation()
-          }
-        })
+        if (stopPropagation) {
+          event.stopPropagation()
+        }
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
@@ -105,11 +102,9 @@ export default Component.extend(PropTypeMixin, {
       $(target).on(handlerOut, this._eventHandlerOut)
     } else {
       this._eventHandler = (event) => {
-        run(() => {
-          if (this.get('stopPropagation')) {
-            event.stopPropagation()
-          }
-        })
+        if (stopPropagation) {
+          event.stopPropagation()
+        }
         // eslint-disable-next-line complexity
         run.next(() => {
           if (this.isDestroyed || this.isDestroying) {

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -64,13 +64,15 @@ export default Component.extend(PropTypeMixin, {
     const handlerOut = this.get('handlerOut')
     if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
-      // eslint-disable-next-line complexity
         run(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return
-          }
           if (this.get('stopPropagation')) {
             event.stopPropagation()
+          }
+        })
+        // eslint-disable-next-line complexity
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
           }
           if (!this.get('visible')) {
             const delay = this.get('delay')
@@ -85,11 +87,13 @@ export default Component.extend(PropTypeMixin, {
 
       this._eventHandlerOut = (event) => {
         run(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return
-          }
           if (this.get('stopPropagation')) {
             event.stopPropagation()
+          }
+        })
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
           }
           run.cancel(this.get('_showDelay'))
           if (this.get('visible')) {
@@ -101,13 +105,15 @@ export default Component.extend(PropTypeMixin, {
       $(target).on(handlerOut, this._eventHandlerOut)
     } else {
       this._eventHandler = (event) => {
-        // eslint-disable-next-line complexity
         run(() => {
-          if (this.isDestroyed || this.isDestroying) {
-            return
-          }
           if (this.get('stopPropagation')) {
             event.stopPropagation()
+          }
+        })
+        // eslint-disable-next-line complexity
+        run.next(() => {
+          if (this.isDestroyed || this.isDestroying) {
+            return
           }
           const delay = this.get('delay')
           if (delay) {

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -27,6 +27,7 @@ export default Component.extend(PropTypeMixin, {
     onHide: PropTypes.func,
     position: PropTypes.string,
     resize: PropTypes.bool,
+    stopPropagation: PropTypes.bool,
     viewport: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object,
@@ -43,6 +44,7 @@ export default Component.extend(PropTypeMixin, {
       offset: 10,
       position: 'bottom',
       resize: true,
+      stopPropagation: false,
       viewport: 'body',
       visible: false,
       autoPosition: 'bottom'
@@ -62,11 +64,14 @@ export default Component.extend(PropTypeMixin, {
     const handlerOut = this.get('handlerOut')
     if (handlerIn && handlerOut) {
       this._eventHandlerIn = (event) => {
-        run.next(() => {
+      // eslint-disable-next-line complexity
+        run(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-
+          if (this.get('stopPropagation')) {
+            event.stopPropagation()
+          }
           if (!this.get('visible')) {
             const delay = this.get('delay')
             if (delay) {
@@ -79,11 +84,13 @@ export default Component.extend(PropTypeMixin, {
       }
 
       this._eventHandlerOut = (event) => {
-        run.next(() => {
+        run(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-
+          if (this.get('stopPropagation')) {
+            event.stopPropagation()
+          }
           run.cancel(this.get('_showDelay'))
           if (this.get('visible')) {
             this.togglePopover(event)
@@ -94,11 +101,14 @@ export default Component.extend(PropTypeMixin, {
       $(target).on(handlerOut, this._eventHandlerOut)
     } else {
       this._eventHandler = (event) => {
-        run.next(() => {
+        // eslint-disable-next-line complexity
+        run(() => {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-
+          if (this.get('stopPropagation')) {
+            event.stopPropagation()
+          }
           const delay = this.get('delay')
           if (delay) {
             if (!this.get('visible')) {

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -124,3 +124,16 @@
     <span class='toggle-content'>Scary monster! RAWRR!</span>
   {{/frost-popover}}
 </div>
+
+<h2>Event Propogation</h2>
+<div class='event-propogation-container' onclick="alert('Propgated')" style="position: relative;">
+  {{frost-button hook='propogateButton' size='small' priority='primary' class='propogate' text='Allow Propogation'}}
+  {{#frost-popover target='.propogate' position='auto'}}
+    <span class='inside'>Allowed Propogation</span>
+  {{/frost-popover}}
+  {{#frost-button hook='stopPropogateButton' size='small' priority='primary' class='stop-propogate' text='Stop Propogation'}}
+    {{#frost-popover target='.stop-propogate' position='auto' closest=true stopPropagation=true}}
+      <span class='inside'>Stopped Propogation</span>
+    {{/frost-popover}}
+  {{/frost-button}}
+</div>

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -4,6 +4,7 @@ import {integration} from 'ember-test-utils/test-support/setup-component-test'
 import hbs from 'htmlbars-inline-precompile'
 import $ from 'jquery'
 import {beforeEach, describe, it} from 'mocha'
+import sinon from 'sinon'
 
 const test = integration('frost-popover')
 describe(test.label, function () {
@@ -150,6 +151,51 @@ describe(test.label, function () {
         expect(popoverRect.left >= viewportRect.left).to.equal(true)
         done()
       }, 100)
+    }, 100)
+  })
+
+  it('should propogate event by default', function (done) {
+    let spy = sinon.spy()
+    this.set('spy', () => {
+      spy()
+    })
+    this.render(hbs`
+    <div class='event-propogation-container' onclick={{action spy}} style="position: relative;">
+        {{frost-button hook='propogateButton' size='small' priority='primary' 
+          class='propogate' text='Allow Propogation'}}
+        {{#frost-popover target='.propogate' position='auto'}}
+          <span class='inside'>Allowed Propogation</span>
+        {{/frost-popover}}
+   </div>
+    `)
+    run.later(() => {
+      $('.propogate').click()
+      run.later(() => {
+        expect(spy.callCount).to.gte(1)
+        done()
+      }, 200)
+    }, 100)
+  })
+
+  it('should not propogate event when stopPropagation=true', function (done) {
+    let spy = sinon.spy()
+    this.setProperties({spy})
+    this.render(hbs`
+    <div class='event-propogation-container' onclick={{action spy}} style="position: relative;">
+    {{#frost-button hook='stopPropogateButton' size='small' priority='primary' 
+      class='stop-propogate' text='Stop Propogation'}}
+    {{#frost-popover target='.stop-propogate' position='auto' closest=true stopPropagation=true}}
+      <span class='inside'>Stopped Propogation</span>
+    {{/frost-popover}}
+  {{/frost-button}}
+   </div>
+    `)
+    run.later(() => {
+      $('.propogate').click()
+      run.later(() => {
+        expect(spy.callCount).to.equal(0)
+        done()
+      }, 200)
     }, 100)
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* add `event.stopPropagation()` option to popover
