### PR TITLE
Added hideDelay and option to allow content to inherit events

### DIFF
--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -130,7 +130,7 @@ export default Component.extend(PropTypeMixin, {
           if (delay || hideDelay) {
             let delayToUse = this.get('visible') ? hideDelay : delay
             if (delayToUse) {
-              this.showDelay(event, hideDelay)
+              this.showDelay(event, delayToUse)
             } else {
               this.togglePopover(event)
             }

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
-const {$, Component, isPresent, run, typeOf} = Ember
+const {$, Component, get, isPresent, run, typeOf} = Ember
+import {task, timeout} from 'ember-concurrency'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-popover'
@@ -12,13 +13,16 @@ export default Component.extend(PropTypeMixin, {
   layout,
   classNameBindings: ['visible:visible:invisible', 'autoPosition'],
   classNames: ['tooltip-frost-popover'],
+
   propTypes: {
     closest: PropTypes.bool,
     delay: PropTypes.number,
+    hideDelay: PropTypes.number, // This doesn't currently properly with 'click'
     event: PropTypes.string,
     excludePadding: PropTypes.bool,
     handlerIn: PropTypes.string,
     handlerOut: PropTypes.string,
+    includeContentInEvents: PropTypes.bool, // making this true lets the content also inheret events properly
     index: PropTypes.number,
     offset: PropTypes.number,
     onDisplay: PropTypes.func,
@@ -39,6 +43,7 @@ export default Component.extend(PropTypeMixin, {
       event: 'click',
       excludePadding: false,
       index: 0,
+      includeContentInEvents: false,
       offset: 10,
       position: 'bottom',
       resize: true,
@@ -49,10 +54,14 @@ export default Component.extend(PropTypeMixin, {
     }
   },
 
+  cancelShowDelayTask () {
+    if (this.showDelayTask) {
+      this.get('showDelayTask').cancelAll()
+    }
+  },
+
   showDelay (event, delay) {
-    return run.later(() => {
-      this.togglePopover(event)
-    }, delay)
+    this.get('showDelayTask').perform(event, delay)
   },
 
   didInsertElement () {
@@ -71,10 +80,11 @@ export default Component.extend(PropTypeMixin, {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
+          this.cancelShowDelayTask()
           if (!this.get('visible')) {
             const delay = this.get('delay')
             if (delay) {
-              this.set('_showDelay', this.showDelay(event, delay))
+              this.showDelay(event, delay)
             } else {
               this.togglePopover(event)
             }
@@ -90,9 +100,14 @@ export default Component.extend(PropTypeMixin, {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
-          run.cancel(this.get('_showDelay'))
+          this.cancelShowDelayTask()
           if (this.get('visible')) {
-            this.togglePopover(event)
+            const hideDelay = this.get('hideDelay')
+            if (hideDelay) {
+              this.showDelay(event, hideDelay)
+            } else {
+              this.togglePopover(event)
+            }
           }
         })
       }
@@ -108,12 +123,16 @@ export default Component.extend(PropTypeMixin, {
           if (this.isDestroyed || this.isDestroying) {
             return
           }
+          this.cancelShowDelayTask()
           const delay = this.get('delay')
-          if (delay) {
-            if (!this.get('visible')) {
-              this.set('_showDelay', this.showDelay(event, delay))
+          const hideDelay = this.get('hideDelay')
+
+          if (delay || hideDelay) {
+            let delayToUse = this.get('visible') ? hideDelay : delay
+            if (delayToUse) {
+              this.showDelay(event, hideDelay)
             } else {
-              run.cancel(this.get('_showDelay'))
+              this.togglePopover(event)
             }
           } else {
             this.togglePopover(event)
@@ -136,7 +155,7 @@ export default Component.extend(PropTypeMixin, {
     } else {
       $(target).off(event, this._eventHandler)
     }
-    run.cancel(this.get('_showDelay'))
+    this.cancelShowDelayTask()
     this.unregisterClickOff()
   },
 
@@ -146,8 +165,9 @@ export default Component.extend(PropTypeMixin, {
    */
   togglePopover (event) {
     const popover = this.get('element')
-    if ($(event.target).closest(popover).length === 0) {
-      this.send('togglePopover')
+    if ($(event.target).closest(popover).length === 0 ||
+      (get(this, 'includeContentInEvents') === true && event.target === popover)) {
+      this.send('togglePopover', event)
     }
   },
 
@@ -158,6 +178,7 @@ export default Component.extend(PropTypeMixin, {
   closePopover (event) {
     let popover = this.get('element')
     if ($(event.target).closest(popover).length === 0) {
+      this.get('showDelayTask').cancelAll()
       this.set('visible', false)
       this.unregisterClickOff()
     }
@@ -422,6 +443,13 @@ export default Component.extend(PropTypeMixin, {
     return offset
   },
 
+  showDelayTask: task(function * (event, delay) {
+    if (delay) {
+      yield timeout(delay)
+    }
+    this.togglePopover(event)
+  }).restartable(),
+
   actions: {
     close (action) {
       if (this.get('isDestroyed')) {
@@ -433,7 +461,8 @@ export default Component.extend(PropTypeMixin, {
         action()
       }
     },
-    togglePopover () {
+
+    togglePopover (event) {
       this.toggleProperty('visible')
       const position = this.get('position')
 

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -17,7 +17,7 @@ export default Component.extend(PropTypeMixin, {
   propTypes: {
     closest: PropTypes.bool,
     delay: PropTypes.number,
-    hideDelay: PropTypes.number, // This doesn't currently properly with 'click'
+    hideDelay: PropTypes.number, // This currently doesn't work properly with 'click'
     event: PropTypes.string,
     excludePadding: PropTypes.bool,
     handlerIn: PropTypes.string,

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -72,7 +72,7 @@
 {{/frost-button}}
 
 <h2>Hide Delay display</h2>
-This feature doesn't properly work with 'click' at the moment.<br/><br/>
+This feature doesn't properly work with 'click' at the moment.<br><br>
 {{#frost-button hook='mouseEnterHideDelayButton' size='small' priority='primary' class='child' text='Hover me!'}}
   {{#frost-popover target='.child' hideDelay=500 handlerIn='mouseenter' handlerOut='mouseleave' excludePadding=true closest=true includeContentInEvents=true}}
     <span class='inside'>Hover me hide delayed!</span>

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -66,8 +66,16 @@
 {{/frost-button}}
 
 {{#frost-button hook='mouseEnterDelayButton' size='small' priority='primary' class='child' text='Hover me!'}}
-  {{#frost-popover target='.child' delay=500 handlerIn='mouseenter' handlerOut='mouseleave' excludePadding=true closest=true}}
+  {{#frost-popover target='.child' delay=500 handlerIn='mouseenter' handlerOut='mouseleave' excludePadding=true closest=true includeContentInEvents=true}}
     <span class='inside'>Hover me delayed!</span>
+  {{/frost-popover}}
+{{/frost-button}}
+
+<h2>Hide Delay display</h2>
+This feature doesn't properly work with 'click' at the moment.<br/><br/>
+{{#frost-button hook='mouseEnterHideDelayButton' size='small' priority='primary' class='child' text='Hover me!'}}
+  {{#frost-popover target='.child' hideDelay=500 handlerIn='mouseenter' handlerOut='mouseleave' excludePadding=true closest=true includeContentInEvents=true}}
+    <span class='inside'>Hover me hide delayed!</span>
   {{/frost-popover}}
 {{/frost-button}}
 

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {$, run} = Ember
+import wait from 'ember-test-helpers/wait'
 import {integration} from 'ember-test-utils/test-support/setup-component-test'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
@@ -100,6 +101,40 @@ describe(test.label, function () {
     })
   })
 
+  describe('when hide delay sets to 500ms with handlerIn and handlerOut', function () {
+    this.timeout(5000)
+    beforeEach(function () {
+      this.render(hbs`
+        <div id='foo' class='target'>
+          click test
+        </div>
+        {{#frost-popover target='#foo' hideDelay=500 handlerIn='mouseenter' handlerOut='mouseleave'}}
+          <span class='inside'>Inside</span>
+        {{/frost-popover}}
+      `)
+      return wait().then(() => {
+        $('#foo').mouseenter()
+        return wait()
+      })
+    })
+
+    it('should still be visible after 400ms', function (done) {
+      $('#foo').mouseleave()
+      run.later(function () {
+        expect($('.visible')).to.have.length(1)
+        done()
+      }, 400)
+    })
+
+    it('should not longer be visible after 700ms', function (done) {
+      $('#foo').mouseleave()
+      run.later(function () {
+        expect($('.visible')).to.have.length(0)
+        done()
+      }, 600)
+    })
+  })
+
   describe('when delay sets to 500ms with click event', function () {
     this.timeout(5000)
     beforeEach(function () {
@@ -162,7 +197,7 @@ describe(test.label, function () {
       })
       this.render(hbs`
       <div class='event-propogation-container' onmousedown={{action spy}} style="position: relative;">
-        {{#frost-button hook='stopPropogateButton' size='small' priority='primary' 
+        {{#frost-button hook='stopPropogateButton' size='small' priority='primary'
           class='propogate' text='Stop Propogation'}}
           {{#frost-popover target='.propogate' event='mousedown' position='auto' closest=true}}
             <span class='inside'>Stopped Propogation</span>
@@ -190,9 +225,9 @@ describe(test.label, function () {
       })
       this.render(hbs`
         <div class='event-propogation-container' onmousedown={{action spy}} style="position: relative;">
-          {{#frost-button hook='stopPropogateButton' size='small' priority='primary' 
+          {{#frost-button hook='stopPropogateButton' size='small' priority='primary'
             class='stop-propogate' text='Stop Propogation'}}
-            {{#frost-popover target='.stop-propogate' position='auto' event='mousedown' 
+            {{#frost-popover target='.stop-propogate' position='auto' event='mousedown'
             closest=true stopPropagation=true}}
               <span class='inside'>Stopped Propogation</span>
             {{/frost-popover}}

--- a/tests/integration/components/frost-popover-test.js
+++ b/tests/integration/components/frost-popover-test.js
@@ -135,6 +135,40 @@ describe(test.label, function () {
     })
   })
 
+  describe('when hide delay sets to 500ms with mouseenter/leave for event', function () {
+    this.timeout(5000)
+    beforeEach(function () {
+      this.render(hbs`
+        <div id='foo' class='target'>
+          click test
+        </div>
+        {{#frost-popover target='#foo' hideDelay=500 event='mouseenter mouseleave'}}
+          <span class='inside'>Inside</span>
+        {{/frost-popover}}
+      `)
+      return wait().then(() => {
+        $('#foo').mouseenter()
+        return wait()
+      })
+    })
+
+    it('should still be visible after 400ms', function (done) {
+      $('#foo').mouseleave()
+      run.later(function () {
+        expect($('.visible')).to.have.length(1)
+        done()
+      }, 400)
+    })
+
+    it('should not longer be visible after 700ms', function (done) {
+      $('#foo').mouseleave()
+      run.later(function () {
+        expect($('.visible')).to.have.length(0)
+        done()
+      }, 600)
+    })
+  })
+
   describe('when delay sets to 500ms with click event', function () {
     this.timeout(5000)
     beforeEach(function () {


### PR DESCRIPTION
This addresses #62

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** hideDelay option (doesn't work properly for 'click')
* **Added** include content in events option to inherit events