### PR TITLE
Feature/call handle hide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ ember install ember-frost-popover
 | Option | `stopPropagation` | | If set to true event handlers will call `event.stopPropagation()` |
 | Option | `target` |  | The selector string of the target that activates the popover |
 | Option | `viewport`| | The selector for the viewport. Defaults to 'body' |
+| Option | `handleHideOnClose`| | If set to true, calls the onHide() function provided in the case where a click would occur outside the button that opened the popover. Defaults to 'false' |
 
 ## Specifying Target
 

--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -20,6 +20,7 @@ export default Component.extend(PropTypeMixin, {
     hideDelay: PropTypes.number, // This currently doesn't work properly with 'click'
     event: PropTypes.string,
     excludePadding: PropTypes.bool,
+    handleHideOnClose: PropTypes.bool,
     handlerIn: PropTypes.string,
     handlerOut: PropTypes.string,
     index: PropTypes.number,
@@ -41,6 +42,7 @@ export default Component.extend(PropTypeMixin, {
       closest: false,
       event: 'click',
       excludePadding: false,
+      handleHideOnClose: false,
       index: 0,
       offset: 10,
       position: 'bottom',
@@ -213,7 +215,7 @@ export default Component.extend(PropTypeMixin, {
     const popover = this.get('element')
 
     if ($(event.target).closest(popover).length === 0 ||
-        (handlerIn === 'mouseenter' && handlerOut === 'mouseleave')) {
+      (handlerIn === 'mouseenter' && handlerOut === 'mouseleave')) {
       this.send('togglePopover', event)
     }
   },
@@ -228,6 +230,9 @@ export default Component.extend(PropTypeMixin, {
       this.get('showDelayTask').cancelAll()
       this.set('visible', false)
       this.unregisterClickOff()
+      if (this.get('handleHideOnClose')) {
+        this.handleHide()
+      }
     }
   },
 


### PR DESCRIPTION
# Overview

fixes issue #76 Call handleHide() when a user clicks outside the popover

## Summary
now if the user passes true to the property `handleHideOnClose`, `handleHide()` is being called when the user clicks out of the popover

## Issue Number(s)
#76 

* Closes #76 

## Screenshots or recordings
![image](https://user-images.githubusercontent.com/1723490/39592177-01765846-4ed4-11e8-8b1c-7af869a6a7a8.png)
now if we click beside the popover or it's opening button, handleHide() is called

# Semver
#minor#

# CHANGELOG

- calling handleHide() when the switch handleHideOnClose is set to true
