### PR TITLE
- call handleHide() on close of popover

### DIFF
--- a/addon/components/frost-popover.js
+++ b/addon/components/frost-popover.js
@@ -228,6 +228,7 @@ export default Component.extend(PropTypeMixin, {
       this.get('showDelayTask').cancelAll()
       this.set('visible', false)
       this.unregisterClickOff()
+      this.handleHide()
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "contributors": [
     "Sophy Pal (https://github.com/sophypal)",
-    "Matthew Dahl (https://github.com/sandersky)"
+    "Matthew Dahl (https://github.com/sandersky)",
+    "Martin Heon (https://github.com/mo0om)"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
# Overview

fixes issue #76 Call handleHide() when a user clicks outside the popover

## Summary
Always call  `handleHide()` when the user clicks out of the popover

## Issue Number(s)
#76 

* Closes #76 

## Screenshots or recordings
![image](https://user-images.githubusercontent.com/1723490/39592177-01765846-4ed4-11e8-8b1c-7af869a6a7a8.png)
now if we click beside the popover or it's opening button, handleHide() is called

# Semver
#major#

# CHANGELOG

- calling handleHide() on close of popover
